### PR TITLE
Added ability to submit gravity sensor data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # Brewer's Friend (brewersfriend.com) stream plugin for CraftBeerPi3
 
-Use this plugin to send your fermenation temperatures to Brewer's Friend
+Use this plugin to send your fermenation temperatures and gravities to Brewer's Friend
 
 ## Installation
 
 Download and Install this Plugin via the CraftBeerPi user interface
 or pull into the [craftbeerpi]/modules/plugins/ directory
 
-Set the api key from https://www.brewersfriend.com/homebrew/profile/account#integrations
+Set the following parameters in CraftBeerPi3:
+* brewersfriend_api_key: The api key from https://www.brewersfriend.com/homebrew/profile/account#integrations
+* brewersfriend_temp_sensor: The name of the Temperature sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no temperature sensor.
+* brewersfriend_gravity_sensor: The name of the Gravity sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no gravity sensor.
+
+Additional parameters (default values are fine most of the time):
+* brewersfriend_api_url: API URL, default: https://log.brewersfriend.com/stream/
+* brewersfriend_temp_unit: Temperature unit of sensor (C or F for Celsius or Fahrenheit) default: C
+* brewersfriend_gravity_unit: Gravity unit of sensor (G or P for Gravity or Plato), default: G
 
 ## Updates
 
-Temperatures will update every 15 minutes to Brewer's Friend for all fermenters that are set to automatic
+Temperatures will update every 15 minutes to Brewer's Friend for all fermenters that are set to automatic.
 
 You can view the logs and attach to a brew session under the Fermentation tab in your brew session within Brewer's Friend

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brewer's Friend (brewersfriend.com) stream plugin for CraftBeerPi3
 
-Use this plugin to send your fermenation temperatures and gravities to Brewer's Friend
+Use this plugin to send your fermenation temperatures and gravities to Brewer's Friend.
 
 ## Installation
 
@@ -8,17 +8,17 @@ Download and Install this Plugin via the CraftBeerPi user interface
 or pull into the [craftbeerpi]/modules/plugins/ directory
 
 Set the following parameters in CraftBeerPi3:
-* brewersfriend_api_key: The api key from https://www.brewersfriend.com/homebrew/profile/account#integrations
-* brewersfriend_temp_sensor: The name of the Temperature sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no temperature sensor.
-* brewersfriend_gravity_sensor: The name of the Gravity sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no gravity sensor.
+* `brewersfriend_api_key`: The api key from https://www.brewersfriend.com/homebrew/profile/account#integrations
+* `brewersfriend_temp_sensor`: The name of the Temperature sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no temperature sensor.
+* `brewersfriend_gravity_sensor`: The name of the Gravity sensor for all fermenters being submitted to Brewer's Friend. This is one of "sensor", "sensor2", or "sensor3", and must be consistent on all fermenters. Leave empty if no gravity sensor.
 
 Additional parameters (default values are fine most of the time):
-* brewersfriend_api_url: API URL, default: https://log.brewersfriend.com/stream/
-* brewersfriend_temp_unit: Temperature unit of sensor (C or F for Celsius or Fahrenheit) default: C
-* brewersfriend_gravity_unit: Gravity unit of sensor (G or P for Gravity or Plato), default: G
+* `brewersfriend_api_url`: API URL, default: https://log.brewersfriend.com/stream/
+* `brewersfriend_temp_unit`: Temperature unit of sensor (C or F for Celsius or Fahrenheit) default: C
+* `brewersfriend_gravity_unit`: Gravity unit of sensor (G or P for Gravity or Plato), default: G
 
 ## Updates
 
 Temperatures will update every 15 minutes to Brewer's Friend for all fermenters that are set to automatic.
 
-You can view the logs and attach to a brew session under the Fermentation tab in your brew session within Brewer's Friend
+You can view the logs and attach to a brew session under the Fermentation tab in your brew session within Brewer's Friend.

--- a/__init__.py
+++ b/__init__.py
@@ -1,37 +1,81 @@
 from modules import cbpi
 import requests
 
-bf_uri = "https://log.brewersfriend.com/stream/"
+def get_param(param_name, default_value, param_type, param_desc):
+    value = cbpi.get_config_parameter(param_name, None)
+    if value is None:
+        cbpi.add_config_parameter(param_name, default_value, param_type, param_desc)
+        return default_value
+    return value
 
-def bf_api_key():
-  api_key = cbpi.get_config_parameter('brewersfriend_api_key', None)
-  if api_key is None:
-    try:
-      cbpi.add_config_parameter("brewersfriend_api_key", "", "text", "BrewersFriend API Key")
-      return ""
-    except:
-      cbpi.notify("Brewer's Friend Error", "Unable to update brewersfriend_api_key parameter within database. Try updating CraftBeerPi and reboot.", type="danger", timeout=None)
-  else:
-    return api_key
+def get_config():
+    config = {}
+    config['api_url'] = get_param("brewersfriend_api_url", "https://log.brewersfriend.com/stream/", "text", "BrewersFriend API URL Prefix")
+    config['api_key'] = get_param("brewersfriend_api_key", "", "text", "BrewersFriend API Key")
+    config['temp_sensor'] = get_param("brewersfriend_temp_sensor", "", "sensor", "BrewersFriend temperature sensor, i.e. 'sensor'")
+    config['temp_unit'] = get_param("brewersfriend_temp_unit", "C", "text", "BrewersFriend temperature unit (C or F for Celsius or Fahrenheit)")
+    config['gravity_sensor'] = get_param("brewersfriend_gravity_sensor", "", "sensor", "BrewersFriend gravity sensor, i.e. 'sensor2'")
+    config['gravity_unit'] = get_param("brewersfriend_gravity_unit", "G", "text", "BrewersFriend gravity unit (G or P for Gravity or Plato)")
+    return config
 
+def log(s):
+    print(s)
+    cbpi.app.logger.info(s)
+    # cbpi.notify("bf_task", s, type="danger", timeout=None)
 
-@cbpi.backgroundtask(key="brewersfriend_task", interval=900)
-def brewersfriend_background_task(api):
-  api_key = bf_api_key()
-  if api_key == "":
-    cbpi.notify("Brewer's Friend Error", "API key not set. Update brewersfriend_api_key parameter within System > Parameters.", type="danger", timeout=None)
-    return
+def bf_submit(api_url, api_key, data):
+    response = requests.post(api_url + api_key, json=data)
+    if response.status_code == 200:
+        log("Submitted data: " + str(data))
+        return True
+    else:
+        log("Received unsuccessful response. Ensure API key is correct. HTTP Error Code: " + str(response.status_code))
+        return False
 
-  for i, fermenter in cbpi.cache.get("fermenter").iteritems():
-    if fermenter.state is not False:
-      try:
-        name = fermenter.name
-        temp = fermenter.instance.get_temp()
-        unit = cbpi.get_config_parameter("unit", "C")
-        data = {"name": name, "temp": temp, "temp_unit": unit}
-        response = requests.post(bf_uri + api_key, json=data)
-        if response.status_code != 200:
-          cbpi.notify("Brewer's Friend Error", "Received unsuccessful response. Ensure API key is correct. HTTP Error Code: " + str(response.status_code), type="danger", timeout=None)
-      except:
-        cbpi.notify("Brewer's Friend Error", "Unable to send message.", type="danger", timeout=None)
-        pass
+def get_fermenter_sensors_data(fermenter, temp_sensor, temp_unit, gravity_sensor, gravity_unit):
+    data = {"name": fermenter.name}
+    gravity = get_sensor_value(fermenter, gravity_sensor)
+    temp = get_sensor_value(fermenter, temp_sensor)
+    if gravity:
+        data['gravity'] = gravity
+        data['gravity_unit'] = gravity_unit
+    if temp:
+        data['temp'] = temp
+        data['temp_unit'] = temp_unit
+    return data
+
+def get_sensor_value(fermenter, sensor):
+    if sensor != "":
+        return cbpi.get_sensor_value(int(getattr(fermenter, sensor)))
+    else:
+        return False
+
+@cbpi.backgroundtask(key="bf_task", interval=900)
+def bf_background_task(api):
+    log("Brewer's Friend START")
+    config = get_config()
+
+    if config['api_key'] == "":
+        log("API key not set. Update brewersfriend_api_key parameter within System > Parameters.")
+        return
+    if config['gravity_sensor'] == "" and config['temp_sensor'] == "":
+        log("No temperature or gravity sensors are set in the parameters.")
+        return
+
+    log("Finding fermenter sensors...")
+    for i, fermenter in cbpi.cache.get("fermenter").iteritems():
+        log("Fermenter: " + str(i) + ": " + fermenter.name + ", State: " + str(fermenter.state))
+        if fermenter.state is not True:
+            continue
+        try:
+            data = get_fermenter_sensors_data(
+                fermenter,
+                config['temp_sensor'],
+                config['temp_unit'],
+                config['gravity_sensor'],
+                config['gravity_unit']
+            )
+            bf_submit(config['api_url'], config['api_key'], data)
+        except Exception as e:
+            log("Unable to send message: " + str(e))
+            pass

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,10 @@
 from modules import cbpi
 import requests
 
-def get_param(param_name, default_value, param_type, param_desc):
+def get_param(param_name, default_value, param_type, param_desc, param_opts=None):
     value = cbpi.get_config_parameter(param_name, None)
     if value is None:
-        cbpi.add_config_parameter(param_name, default_value, param_type, param_desc)
+        cbpi.add_config_parameter(param_name, default_value, param_type, param_desc, param_opts)
         return default_value
     return value
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,10 +12,10 @@ def get_config():
     config = {}
     config['api_url'] = get_param("brewersfriend_api_url", "https://log.brewersfriend.com/stream/", "text", "BrewersFriend API URL Prefix")
     config['api_key'] = get_param("brewersfriend_api_key", "", "text", "BrewersFriend API Key")
-    config['temp_sensor'] = get_param("brewersfriend_temp_sensor", "", "sensor", "BrewersFriend temperature sensor, i.e. 'sensor'")
-    config['temp_unit'] = get_param("brewersfriend_temp_unit", "C", "text", "BrewersFriend temperature unit (C or F for Celsius or Fahrenheit)")
-    config['gravity_sensor'] = get_param("brewersfriend_gravity_sensor", "", "sensor", "BrewersFriend gravity sensor, i.e. 'sensor2'")
-    config['gravity_unit'] = get_param("brewersfriend_gravity_unit", "G", "text", "BrewersFriend gravity unit (G or P for Gravity or Plato)")
+    config['temp_sensor'] = get_param("brewersfriend_temp_sensor", "sensor", "text", "BrewersFriend temperature sensor, i.e. 'sensor'")
+    config['temp_unit'] = get_param("brewersfriend_temp_unit", "C", "select", "BrewersFriend temperature unit (C or F for Celsius or Fahrenheit)", ["C", "F"])
+    config['gravity_sensor'] = get_param("brewersfriend_gravity_sensor", "", "text", "BrewersFriend gravity sensor, i.e. 'sensor2'")
+    config['gravity_unit'] = get_param("brewersfriend_gravity_unit", "G", "select", "BrewersFriend gravity unit (G or P for Gravity or Plato)", ["G", "P"])
     return config
 
 def log(s):


### PR DESCRIPTION
For people who have a Tilt/iSpindel/etc. and want to submit gravity readings along with temperature data, I've updated the code to allow for that. I've also added config parameters for units, the sensor names for temperature and gravity (which must be consistent across all fermenters). This will work for any combination of temperature and/or gravity sensors, so if you don't have gravity of your fermenter, it will still just submit the one value for temperature.